### PR TITLE
Handle log files that change names

### DIFF
--- a/run_script.sh
+++ b/run_script.sh
@@ -3,7 +3,7 @@
 export GOOGLE_APPLICATION_CREDENTIALS="key.json"
 
 cd /home/andy/bigquery_demo/
-file=`ls -t /var/log/old_win_func/window_functions* | head  -1`
+file=`ls -t /var/log/old_win_func/window_functions* | head  -2`
 
 /home/andy/.virtualenvs/bigquery_demo/bin/python   src/__init__.py  $file
 


### PR DESCRIPTION
When service is restarted the log file changes name - that means we want
to reset the state of the logfile so we can read all of it.

Note this won't process all logs if service restarted multiple times in
a day. This is not the 'correct' way to do things